### PR TITLE
Gripper reboot() command replaced by "clean" reboot

### DIFF
--- a/src/gripper_action/gripper_action.py
+++ b/src/gripper_action/gripper_action.py
@@ -59,7 +59,7 @@ class GripperActionServer(object):
 
         # Verify Grippers Have No Errors and are Calibrated
         if self._gripper.error():
-            self._gripper.reboot()
+            self._gripper.reset()
             if self._gripper.error():
                 msg = ("Stopping %s action server - Unable to clear error" %
                        self._gripper.name)


### PR DESCRIPTION
Gripper reboots do not ensure errors are cleared normally,
especially on gripper errors during boot. Therefore a new
"clean" reboot command has been introduced to check and
clear errors after doing a reboot.
- New clean reboot version replaces same reboot() method
  in python interface.
- Old gripper reboot() command now called _cmd_reboot() in
  interface.
- Programs should use reset() for resetting errors, and reboot()
  for rebooting grippers and/or clearing calibration. This is
  reflected in the modification in gripper_action.py
