### PR TITLE
Add clear_calibration and cmd sequencing to gripper interface

### DIFF
--- a/src/baxter_interface/gripper.py
+++ b/src/baxter_interface/gripper.py
@@ -377,14 +377,14 @@ class Gripper(object):
         if self._state.calibrated != True:
             msg = "Unable to command %s position until calibrated" % self.name
             rospy.logwarn(msg)
+            return False
 
         cmd = EndEffectorCommand.CMD_GO
         arguments = {"position": self._clip(position)}
         if self.type() == 'electric':
-            cmd_test = lambda: (((fabs(self._state.position - position)
+            cmd_test = lambda: ((fabs(self._state.position - position)
                                   < self._parameters['dead_zone'])
-                                 or self._state.gripping == True) and
-                                self._state.calibrated == True)
+                                 or self._state.gripping == True)
             return self.command(
                                 cmd,
                                 block,


### PR DESCRIPTION
EDIT: Updated (and kind of took over) this pull request. [-rsl]
- Rewrite of command function to account for sequencing:
  - i.e. waiting for gripper to acknowledge the reception and processing of a command before testing for success in the dataflow's
- Add clear_calibration gripper command to python interface
- [rsl] ~~Adds reboot to gripper interface calibrate command~~
  - Added clear_calibration() and check for errors instead, same idea.
- Removes info/warn on reboot with expected behavior
- Reorder of some function args

---

more details in this copy of commit message 1b5f88f357ee88f6830a78cfac144da8048da63e:

gripper: consistent arg orders; robust comparisons of tri-states …
- Changed to consistent arg order of `block` before `timeout`
  for all gripper functions.
- Verified logic consistency across gripper interface.
  - Many of the uint8 fields in the gripper /state topic are
    actually 'Tri-state' variables, not just '0'/'1' bools.
    ('2' means 'unknown' or transitionary state).
  - This means, only the 1st ex prints for tri_var=2:
     if tri_var: print("will print - condtion evals true")
     if tri_var == True: print("won't print - condition false")

Note: One or two of these cleanup changes were made in the parent
conflict-resolution merge.
