### PR TITLE
Joint trajectory action server goal_time and interpolated initial movement

### DIFF
--- a/cfg/GripperActionServer.cfg
+++ b/cfg/GripperActionServer.cfg
@@ -34,7 +34,7 @@ from dynamic_reconfigure.parameter_generator_catkin import (
 
 gen = ParameterGenerator()
 
-grippers = ('left_gripper', 'right_gripper') 
+grippers = ('left_gripper', 'right_gripper')
 
 params = (
     '_timeout', '_goal', '_velocity', '_moving_force', '_holding_force',

--- a/cfg/JointTrajectoryActionServer.cfg
+++ b/cfg/JointTrajectoryActionServer.cfg
@@ -60,10 +60,18 @@ default = (-1.0, -1.0, 0.25, 2.0, 0.0, 0.0,)
 max = (3.0, 3.0, 2.5, 500.0, 100.0, 100.0,)
 
 for idx, param in enumerate(params):
-    for joint in joints:
-        gen.add(
-            joint + param, double_t, 0, joint + msg[idx],
-            default[idx], min[idx], max[idx]
+    if idx < 3:
+        for joint in joints:
+            gen.add(
+                joint + param, double_t, 0, joint + msg[idx],
+                default[idx], min[idx], max[idx]
             )
+for joint in joints:
+    for idx, param in enumerate(params):
+        if idx >= 3:
+            gen.add(
+                joint + param, double_t, 0, joint + msg[idx],
+                default[idx], min[idx], max[idx]
+            )	
 
 exit(gen.generate('baxter_interface', '', 'JointTrajectoryActionServer'))

--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -91,6 +91,7 @@ class JointTrajectoryActionServer(object):
         self._pub_rate.publish(self._control_rate)
 
     def _get_trajectory_parameters(self, joint_names):
+        self._goal_time = self._dyn.config['goal_time']
         for jnt in joint_names:
             if not jnt in self._limb.joint_names():
                 rospy.logerr(
@@ -227,9 +228,8 @@ class JointTrajectoryActionServer(object):
             if idx == 0:
                 # If our current time is before the first specified point
                 # in the trajectory, then we should interpolate between
-                # our current position and that point.
-                p1 = JointTrajectoryPoint()
-                p1.positions = self._get_current_position(joint_names)
+                # our start position and that point.
+                p1 = deepcopy(start_point)
             else:
                 p1 = deepcopy(trajectory_points[idx - 1])
 


### PR DESCRIPTION
- Fix to now load and use goal_time. This allows the joint trajectory action server to servo at the commanded goal position until it achieves the goal constraints. Tested to allow for < 0.5 degrees/joint accuracy.
- Interpolated move to first trajectory point now uses the start position instead of current. [RL]
- Cleans up joint trajectory dynamic reconfig generated for more intuitive use.
- ws
