### PR TITLE
package.xml verification/fixes for new repos

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <version>0.7.0</version>
   <description>
     Convenient python interface classes for control
-    of the Baxter robot from Rethink Robotics.
+    of the Baxter Research Robot from Rethink Robotics.
   </description>
 
   <maintainer email="rsdk.support@rethinkrobotics.com">
@@ -13,10 +13,10 @@
   <license>BSD</license>
   <url type="website">http://www.rethinkrobotics.com/sdk</url>
   <url type="repository">
-    https://github.com/RethinkRobotics/sdk-examples
+    https://github.com/RethinkRobotics/baxter_interface
   </url>
   <url type="bugtracker">
-    https://github.com/RethinkRobotics/sdk-examples/issues
+    https://github.com/RethinkRobotics/baxter_interface/issues
   </url>
   <author>Rethink Robotics Inc.</author>
 


### PR DESCRIPTION
Verifying package.xml and version numbers for 0.7.0 release
and the rename and breakout of the Baxter SDK repositories,
especially 'sdk-examples' -> 'baxter'
