### PR TITLE
No error raise and publish once for move_to "once"

### DIFF
--- a/src/baxter_interface/limb.py
+++ b/src/baxter_interface/limb.py
@@ -345,6 +345,7 @@ class Limb(object):
         diffs = [genf(j, a) for j, a in positions.items() if
                  j in self._joint_angle]
 
+        self.set_joint_positions(filtered_cmd())
         baxter_dataflow.wait_for(
             lambda: (all(diff() < settings.JOINT_ANGLE_TOLERANCE
                          for diff in diffs)),
@@ -352,5 +353,6 @@ class Limb(object):
             timeout_msg=("%s limb failed to reach commanded joint positions" %
                          (self.name.capitalize(),)),
             rate=100,
+            raise_on_error=False,
             body=lambda: self.set_joint_positions(filtered_cmd())
             )


### PR DESCRIPTION
Changes Limb interface's move_to_joint_positions() so that it can
be called once without issues.

The move_to fn is intended to be used as blocking, but as it
currently is the only method with the low-pass filter in it,
enabling it to be called quickly (0 timeout) and actually do
something, enables us to use the low-pass filter in a non-
-blocking scenario.
- Sets fn to only warn instead of raise error when arm does
  not make it to goal in time. (should have been that way)
- Adds a single publish before dataflow.wait_for() so that
  0 or small timeouts still command the position once.
