### PR TITLE
Adds limb move_to_joint_positions optional argument - threshold

### DIFF
--- a/src/baxter_interface/limb.py
+++ b/src/baxter_interface/limb.py
@@ -318,7 +318,8 @@ class Limb(object):
                           [0.0, -0.55, 0.0, 0.75, 0.0, 1.26, 0.0]))
         return self.move_to_joint_positions(angles, timeout)
 
-    def move_to_joint_positions(self, positions, timeout=15.0):
+    def move_to_joint_positions(self, positions, timeout=15.0,
+                                threshold=settings.JOINT_ANGLE_TOLERANCE):
         """
         Commands the limb to the provided positions.
 
@@ -326,6 +327,9 @@ class Limb(object):
         @param positions: joint_name:angle command
         @type timeout: float
         @param timeout: seconds to wait for move to finish [15]
+        @type threshold: float
+        @param threshold: position threshold in radians across each joint when
+        move is considered successful [0.008726646]
 
         Waits until the reported joint state matches that specified.
         """
@@ -346,11 +350,11 @@ class Limb(object):
                  j in self._joint_angle]
 
         baxter_dataflow.wait_for(
-            lambda: (all(diff() < settings.JOINT_ANGLE_TOLERANCE
-                         for diff in diffs)),
+            lambda: (all(diff() < threshold for diff in diffs)),
             timeout=timeout,
             timeout_msg=("%s limb failed to reach commanded joint positions" %
                          (self.name.capitalize(),)),
             rate=100,
+            raise_on_error=False,
             body=lambda: self.set_joint_positions(filtered_cmd())
             )


### PR DESCRIPTION
- Optional argument allowing the setting of angular success threshold for joint position moves using move_to_joint_positions in limb.py. Default value is the same 0.008726646 (0.5 degrees) from settings.py. This option allows for fine/gross position settings of joint motions programmatically with each motion.
- move_to_joint_positions no longer raises an exception on failure. It will now simply report its timeout, as raising was overkill for this method.
