### PR TITLE
Fix head nod

### DIFF
--- a/src/baxter_interface/head.py
+++ b/src/baxter_interface/head.py
@@ -154,5 +154,5 @@ class Head(object):
                 timeout=timeout,
                 rate=100,
                 timeout_msg="Failed to complete head nod command",
-                body=lambda: self._pub_nod.publish(True)
+                body=lambda: self._pub_nod.publish(False)
             )


### PR DESCRIPTION
There was a nonsensical second waitfor statement in the command head nod function, that only worked if we just caught the instant between the motor stopping and publishing.
