### PR TITLE
Limb interface tcp_nodelay transport hint

### DIFF
--- a/src/baxter_interface/limb.py
+++ b/src/baxter_interface/limb.py
@@ -85,7 +85,8 @@ class Limb(object):
 
         self._pub_joint_cmd = rospy.Publisher(
             ns + 'joint_command',
-            JointCommand)
+            JointCommand,
+            tcp_nodelay=True)
 
         self._pub_joint_cmd_timeout = rospy.Publisher(
             ns + 'joint_command_timeout',
@@ -95,13 +96,17 @@ class Limb(object):
         _cartesian_state_sub = rospy.Subscriber(
             ns + 'endpoint_state',
             EndpointState,
-            self._on_endpoint_states)
+            self._on_endpoint_states,
+            queue_size=1,
+            tcp_nodelay=True)
 
         joint_state_topic = 'robot/joint_states'
         _joint_state_sub = rospy.Subscriber(
             joint_state_topic,
             JointState,
-            self._on_joint_states)
+            self._on_joint_states,
+            queue_size=1,
+            tcp_nodelay=True)
 
         err_msg = ("%s limb init failed to get current joint_states "
                    "from %s") % (self.name.capitalize(), joint_state_topic)


### PR DESCRIPTION
Adds tcp_nodelay transport hint for limb interface joint state, endpoint state, and joint commands.
Avoids tcp buffering, providing smoother, more reliable timing in both directions.
