### PR TITLE
Adds custom gripper reset convenience methods

### DIFF
--- a/src/baxter_interface/gripper.py
+++ b/src/baxter_interface/gripper.py
@@ -331,7 +331,8 @@ class Gripper(object):
         """
         Resets default properties for custom grippers
 
-        @returns (bool) - True if custom gripper properties reset successfully
+        @return: True if custom gripper properties reset successfully
+        @rtype: bool
         """
         default_id = 131073
         default_ui_type = EndEffectorProperties.CUSTOM_GRIPPER
@@ -366,7 +367,8 @@ class Gripper(object):
         """
         Resets default state for custom grippers
 
-        @returns (bool) - True if custom gripper state reset successfully
+        @return: True if custom gripper state reset successfully
+        @rtype: bool
         """
         state_true = EndEffectorState.STATE_TRUE
         state_unknown = EndEffectorState.STATE_UNKNOWN


### PR DESCRIPTION
Adds gripper convenience methods for resetting custom gripper properties and state.

reset_custom_properties, and reset_custom_state gripper methods

Latches reset_custom_properties, reset_custom_state published setters.
'wait_for' to verify state/properties reset succeeds.

Trac #10027
