### PR TITLE
Namespace Joint Trajectory Action Server Parameters

### DIFF
--- a/scripts/joint_trajectory_action_server.py
+++ b/scripts/joint_trajectory_action_server.py
@@ -49,8 +49,8 @@ from joint_trajectory_action.joint_trajectory_action import (
 
 def start_server(limb, rate, mode):
     print("Initializing node... ")
-    rospy.init_node("rsdk_joint_trajectory_action_server%s" %
-                    ("" if limb == 'both' else "_" + limb,))
+    rospy.init_node("rsdk_%s_joint_trajectory_action_server%s" %
+                    (mode, "" if limb == 'both' else "_" + limb,))
     print("Initializing joint trajectory action server...")
 
     if mode == 'velocity':


### PR DESCRIPTION
Namespaces dynamic reconfigure parameters for the joint trajectory action server to avoid confusion when switching between position or velocity jtas control.
