### PR TITLE
Added queue_size option as required in Indigo to prevent warning

### DIFF
--- a/src/baxter_interface/analog_io.py
+++ b/src/baxter_interface/analog_io.py
@@ -79,7 +79,8 @@ class AnalogIO(object):
         if self._is_output:
             self._pub_output = rospy.Publisher(
                 type_ns + '/command',
-                AnalogOutputCommand)
+                AnalogOutputCommand,
+                queue_size=10)
 
     def _on_io_state(self, msg):
         """

--- a/src/baxter_interface/digital_io.py
+++ b/src/baxter_interface/digital_io.py
@@ -80,7 +80,8 @@ class DigitalIO(object):
         if self._is_output:
             self._pub_output = rospy.Publisher(
                 type_ns + '/command',
-                DigitalOutputCommand)
+                DigitalOutputCommand,
+                queue_size=10)
 
     def _on_io_state(self, msg):
         """

--- a/src/baxter_interface/gripper.py
+++ b/src/baxter_interface/gripper.py
@@ -86,16 +86,19 @@ class Gripper(object):
 
         self._parameters = dict()
 
-        self._cmd_pub = rospy.Publisher(ns + 'command', EndEffectorCommand)
+        self._cmd_pub = rospy.Publisher(ns + 'command', EndEffectorCommand,
+            queue_size=10)
 
         self._prop_pub = rospy.Publisher(ns + 'rsdk/set_properties',
                                          EndEffectorProperties,
-                                         latch=True
+                                         latch=True,
+                                         queue_size=10
                                          )
 
         self._state_pub = rospy.Publisher(ns + 'rsdk/set_state',
                                           EndEffectorState,
-                                          latch=True
+                                          latch=True,
+                                          queue_size=10
                                           )
 
         self._state_sub = rospy.Subscriber(ns + 'state',

--- a/src/baxter_interface/head.py
+++ b/src/baxter_interface/head.py
@@ -55,11 +55,13 @@ class Head(object):
 
         self._pub_pan = rospy.Publisher(
             '/robot/head/command_head_pan',
-            HeadPanCommand)
+            HeadPanCommand,
+            queue_size=10)
 
         self._pub_nod = rospy.Publisher(
             '/robot/head/command_head_nod',
-            Bool)
+            Bool,
+            queue_size=10)
 
         state_topic = '/robot/head/head_state'
         self._sub_state = rospy.Subscriber(

--- a/src/baxter_interface/limb.py
+++ b/src/baxter_interface/limb.py
@@ -85,17 +85,20 @@ class Limb(object):
         self._pub_speed_ratio = rospy.Publisher(
             ns + 'set_speed_ratio',
             Float64,
-            latch=True)
+            latch=True,
+            queue_size=10)
 
         self._pub_joint_cmd = rospy.Publisher(
             ns + 'joint_command',
             JointCommand,
-            tcp_nodelay=True)
+            tcp_nodelay=True,
+            queue_size=10)
 
         self._pub_joint_cmd_timeout = rospy.Publisher(
             ns + 'joint_command_timeout',
             Float64,
-            latch=True)
+            latch=True,
+            queue_size=10)
 
         _cartesian_state_sub = rospy.Subscriber(
             ns + 'endpoint_state',

--- a/src/baxter_interface/robot_enable.py
+++ b/src/baxter_interface/robot_enable.py
@@ -94,7 +94,8 @@ class RobotEnable(object):
 
     def _toggle_enabled(self, status):
 
-        pub = rospy.Publisher('robot/set_super_enable', Bool)
+        pub = rospy.Publisher('robot/set_super_enable', Bool, 
+                              queue_size=10)
 
         baxter_dataflow.wait_for(
             test=lambda: self._state.enabled == status,
@@ -148,7 +149,7 @@ http://sdk.rethinkrobotics.com/wiki/RSDK_Shell#Initialize
                             self._state.error == False and
                             self._state.estop_button == 0 and
                             self._state.estop_source == 0)
-        pub = rospy.Publisher('robot/set_super_reset', Empty)
+        pub = rospy.Publisher('robot/set_super_reset', Empty, queue_size=10)
 
         if (self._state.stopped and
             self._state.estop_button == AssemblyState.ESTOP_BUTTON_PRESSED):
@@ -175,7 +176,7 @@ http://sdk.rethinkrobotics.com/wiki/RSDK_Shell#Initialize
         Simulate an e-stop button being pressed.  Robot must be reset to clear
         the stopped state.
         """
-        pub = rospy.Publisher('robot/set_super_stop', Empty)
+        pub = rospy.Publisher('robot/set_super_stop', Empty, queue_size=10)
         baxter_dataflow.wait_for(
             test=lambda: self._state.stopped == True,
             timeout=3.0,

--- a/src/baxter_interface/robust_controller.py
+++ b/src/baxter_interface/robust_controller.py
@@ -51,7 +51,8 @@ class RobustController(object):
         """
         self._command_pub = rospy.Publisher(
             namespace + '/enable',
-            type(enable_msg))
+            type(enable_msg),
+            queue_size=10)
         self._status_sub = rospy.Subscriber(
             namespace + '/status',
             RobustControllerStatus,


### PR DESCRIPTION
Fix for https://github.com/RethinkRobotics/baxter_examples/issues/32

I'm not 100% sure if it should be value `10` or `None`, but `None` doesn't remove the warning message 

@dirk-thomas why does not suppress the error even though it was the default in groovy and earlier? Do you know why was this change made in Indigo anyway when it makes ROS a bit more complicated?

Thanks!
