### PR TITLE
Add head action server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ generate_dynamic_reconfigure_options(
   cfg/PositionJointTrajectoryActionServer.cfg
   cfg/VelocityJointTrajectoryActionServer.cfg
   cfg/GripperActionServer.cfg
+  cfg/HeadActionServer.cfg
 )
 
 catkin_package(

--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,12 @@ baxter_interface Repository Overview
      |   +-- baxter_dataflow/                  timing/program flow utilities
      |   +-- joint_trajectory_action/          joint trajectory action implementation
      |   +-- gripper_action/                   gripper action implementation
+     |   +-- head_action/                      head action implementation
      |
      +-- scripts/                              action server executables
      |   +-- joint_trajectory_action_server.py
      |   +-- gripper_action_server.py
+     |   +-- head_action_server.py
      |
      +-- cfg/                                  dynamic reconfigure action configs
 

--- a/cfg/HeadActionServer.cfg
+++ b/cfg/HeadActionServer.cfg
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2013-2014, Rethink Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the Rethink Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from dynamic_reconfigure.parameter_generator_catkin import (
+    ParameterGenerator,
+    double_t,
+)
+
+gen = ParameterGenerator()
+
+params = (
+    'timeout', 'goal'
+    )
+
+msg = (
+    " - Timeout (Seconds) to achieve command or determined gripping",
+    " - Maximum final error",
+    )
+min = (-1.0, 0.0)
+default = (5.0, 0.01)
+max = (20.0, 1.57)
+
+for idx, param in enumerate(params):
+    gen.add(
+        param, double_t, 0, msg[idx],
+        default[idx], min[idx], max[idx]
+        )
+
+exit(gen.generate('baxter_interface', '', 'HeadActionServer'))

--- a/scripts/head_action_server.py
+++ b/scripts/head_action_server.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2013-2014, Rethink Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the Rethink Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Baxter RSDK Head Action Server
+"""
+import argparse
+
+import rospy
+
+from dynamic_reconfigure.server import Server
+
+from baxter_interface.cfg import (
+    HeadActionServerConfig
+)
+from head_action.head_action import (
+    HeadActionServer,
+)
+
+
+def start_server():
+    print("Initializing node... ")
+    rospy.init_node("rsdk_head_action_server")
+    print("Initializing head action server...")
+
+    dynamic_cfg_srv = Server(HeadActionServerConfig,
+                             lambda config, level: config)
+
+    HeadActionServer(dynamic_cfg_srv)
+    print("Running. Ctrl-c to quit")
+    rospy.spin()
+
+def main():
+    start_server()
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()
 d['packages'] = ['baxter_interface', 'baxter_control', 'baxter_dataflow',
-                 'joint_trajectory_action', 'gripper_action']
+                 'joint_trajectory_action', 'gripper_action', 'head_action']
 d['package_dir'] = {'': 'src'}
 
 setup(**d)

--- a/src/head_action/__init__.py
+++ b/src/head_action/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2013-2014, Rethink Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the Rethink Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from .head_action import HeadActionServer

--- a/src/head_action/head_action.py
+++ b/src/head_action/head_action.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2013-2014, Rethink Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the Rethink Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Baxter RSDK Head Action Server
+"""
+from math import fabs
+
+import rospy
+
+import actionlib
+
+from control_msgs.msg import (
+    SingleJointPositionAction,
+    SingleJointPositionFeedback,
+    SingleJointPositionResult, 
+)
+
+import baxter_interface
+
+from baxter_interface import CHECK_VERSION
+
+class HeadActionServer(object):
+    def __init__(self, reconfig_server):
+        self._dyn = reconfig_server
+        self._ns = 'robot/head/head_action'
+        self._head = baxter_interface.Head()
+
+        # Action Server
+        self._server = actionlib.SimpleActionServer(
+            self._ns,
+            SingleJointPositionAction,
+            execute_cb=self._on_head_action,
+            auto_start=False)
+        self._action_name = rospy.get_name()
+        self._server.start()
+
+        # Action Feedback/Result
+        self._fdbk = SingleJointPositionFeedback()
+        self._result = SingleJointPositionResult()
+
+        # Initialize Parameters
+        self._prm = self._head.parameters()
+        self._timeout = 5.0
+
+    def _get_head_parameters(self):
+        self._timeout = self._dyn.config['timeout']
+        self._prm['dead_zone'] = self._dyn.config['goal']
+        self._head.set_parameters(parameters=self._prm)
+
+    def _update_feedback(self):
+        self._fdbk.position = self._head.pan()
+        self._result = self._fdbk
+        self._server.publish_feedback(self._fdbk)
+
+    def _command_head(self, position, speed):
+        self._head.set_pan(position, speed, timeout=self._timeout)
+
+    def _check_state(self, position):
+        return (fabs(self._head.pan() - position) <
+                self._head.parameters()['dead_zone'])
+
+    def _on_head_action(self, goal):
+        position = goal.position
+        velocity = goal.max_velocity
+        # Apply max velocity if specified < 0
+        if velocity < 0.0:
+            velocity = 100.0
+
+        # Pull parameters that will define the head actuation
+        self._get_head_parameters()
+
+        # Reset feedback/result
+        self._update_feedback()
+
+        # 20 Hz head state rate
+        control_rate = rospy.Rate(20.0)
+
+        # Record start time
+        start_time = rospy.get_time()
+
+        def now_from_start(start):
+            return rospy.get_time() - start
+
+        # Continue commanding goal until success or timeout
+        while ((now_from_start(start_time) < self._timeout or
+               self._timeout < 0.0) and not rospy.is_shutdown()):
+            if self._server.is_preempt_requested():
+                rospy.loginfo("%s: Head Action Can't Preempted" %
+                              (self._action_name,))
+                self._server.set_preempted(self._result)
+                return
+            self._update_feedback()
+            if self._check_state(position):
+                self._server.set_succeeded(self._result)
+                return
+            self._command_head(position, velocity)
+            control_rate.sleep()
+
+        if not rospy.is_shutdown():
+            rospy.logerr("%s: Head Command Not Achieved in Allotted Time" %
+                         (self._action_name,))
+        self._update_feedback()
+        self._server.set_aborted(self._result)


### PR DESCRIPTION
Related to #39 .
In this PR,
I added the head_action_server only for head_pan with using SingleJointPosition.
As mentioned in #39 the feedback tilt will not useful, so this time I didn't prepare head_tilt.

The head_pan feedback only include the position of pan. 
Because I can't get speed of pan, the velocity variable in feedback message doesn't make sense.
Head pan can't stop the motion, so when preempt is requested the action server will just return.
For parameter, it only has dead_zone.

I tested on real baxter and confirmed it works. I will send the client PR to baxter_example(I already have) when this is merged.
