### PR TITLE
add dependencies to baxter_core_msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ generate_dynamic_reconfigure_options(
   cfg/HeadActionServer.cfg
 )
 
+add_dependencies(${PROJECT_NAME}_gencfg baxter_core_msgs_generate_messages_py)
+
 catkin_package(
   CATKIN_DEPENDS
   rospy


### PR DESCRIPTION
for #48. Thanks to @rethink-imcmahon.

Cfg will have the dependencies to baxter_core_msgs_generate_messages_py.
