### PR TITLE
Show error message when actionlib serer received only few waypoints

### DIFF
--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -348,6 +348,11 @@ class JointTrajectoryActionServer(object):
             rospy.logerr("%s: Empty Trajectory" % (self._action_name,))
             self._server.set_aborted()
             return
+        elif num_points <= 2:
+            rospy.logerr("%s: From SDK 1.1.0, Trajectory need at least 3 trajectories" % (self._action_name,))
+            self._server.set_aborted()
+            return
+
         rospy.loginfo("%s: Executing requested joint trajectory" %
                       (self._action_name,))
         rospy.logdebug("Trajectory Points: {0}".format(trajectory_points))


### PR DESCRIPTION
When I send joint_trajectory goal msg with few waypoints(fewer than 3 waypoints), this will die in sdk ver 1.1.0.
I know the way I use is wrong, but I think it will be better that we show the error.

When I send trajectory like 2 trajectories. This will die in  https://github.com/RethinkRobotics/baxter_interface/blob/master/src/joint_trajectory_action/bezier.py#L141 and error is below.
```
[INFO] [WallTime: 1423645112.337123] /rsdk_position_w_id_joint_trajectory_action_server: Executing requested joint trajectory
[ERROR] [WallTime: 1423645112.338585] Exception in your execute callback: index -1 is out of bounds for axis 0 with size 0
Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/actionlib/simple_action_server.py", line 299, in executeLoop
    self.execute_callback(goal)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/joint_trajectory_action/joint_trajectory_action.py", line 371, in _on_trajectory_action
    dimensions_dict)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/joint_trajectory_action/joint_trajectory_action.py", line 325, in _compute_bezier_coeff
    d_pts = bezier.de_boor_control_pts(traj_array)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/joint_trajectory_action/bezier.py", line 141, in de_boor_control_pts
    x[N-2, 0] = 6*points_array[-2, col] - points_array[-1, col]
IndexError: index -1 is out of bounds for axis 0 with size 0
```

When I send one trajectory. This will die in  https://github.com/RethinkRobotics/baxter_interface/blob/master/src/joint_trajectory_action/bezier.py#L138 and error is below.

```
[INFO] [WallTime: 1423645173.280719] /rsdk_position_w_id_joint_trajectory_action_server: Executing requested joint trajectory
[ERROR] [WallTime: 1423645173.283250] Exception in your execute callback: negative dimensions are not allowed
Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/actionlib/simple_action_server.py", line 299, in executeLoop
    self.execute_callback(goal)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/joint_trajectory_action/joint_trajectory_action.py", line 371, in _on_trajectory_action
    dimensions_dict)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/joint_trajectory_action/joint_trajectory_action.py", line 325, in _compute_bezier_coeff
    d_pts = bezier.de_boor_control_pts(traj_array)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/joint_trajectory_action/bezier.py", line 138, in de_boor_control_pts
    x = np.zeros((N-1, 1))
ValueError: negative dimensions are not allowed
```


I tested these with change baxter_examples' joint_trajectory_client.py like below(Just commented out)
```
    p1 = positions[limb]
    traj.add_point(p1, 7.0)                                                                                                                                                        
    # traj.add_point([x * 0.75 for x in p1], 9.0)                                                                                                                                    
    # traj.add_point([x * 1.25 for x in p1], 12.0)  
```