### PR TITLE
Prevent JTAS Error with few Points

### DIFF
--- a/src/joint_trajectory_action/bezier.py
+++ b/src/joint_trajectory_action/bezier.py
@@ -135,19 +135,25 @@ def de_boor_control_pts(points_array, d0=None,
     # Construct de Boor Control Points from A matrix
     d_pts = np.zeros((N+3, k))
     for col in range(0, k):
-        x = np.zeros((N-1, 1))
-        # Compute start / end conditions
-        if natural:
-            x[N-2, 0] = 6*points_array[-2, col] - points_array[-1, col]
-            x[0, 0] = 6*points_array[1, col] - points_array[0, col]
-        else:
-            x[N-2, 0] = 6*points_array[-2, col] - 1.5*dN[0, col]
-            x[0, 0] = 6*points_array[1, col] - 1.5*d0[0, col]
-        x[range(1, N-3+1), 0] = 6*points_array[range(2, N-2+1), col]
-        # Solve bezier interpolation
+        x = np.zeros((max(N-1, 1), 1))
         if N > 2:
+            # Compute start / end conditions
+            if natural:
+                x[N-2, 0] = 6*points_array[-2, col] - points_array[-1, col]
+                x[0, 0] = 6*points_array[1, col] - points_array[0, col]
+            else:
+                x[N-2, 0] = 6*points_array[-2, col] - 1.5*dN[0, col]
+                x[0, 0] = 6*points_array[1, col] - 1.5*d0[0, col]
+            x[range(1, N-3+1), 0] = 6*points_array[range(2, N-2+1), col]
+            # Solve bezier interpolation
             d_pts[2:N+1, col] = np.linalg.solve(A, x).T
         else:
+            # Compute start / end conditions
+            if natural:
+                x[0, 0] = 6*points_array[1, col] - points_array[0, col]
+            else:
+                x[0, 0] = 6*points_array[1, col] - 1.5*d0[col]
+            # Solve bezier interpolation
             d_pts[2, col] = x / A
     # Store off start and end positions
     d_pts[0, :] = points_array[0, :]

--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -379,9 +379,19 @@ class JointTrajectoryActionServer(object):
 
         # Compute Full Bezier Curve Coefficients for all 7 joints
         pnt_times = [pnt.time_from_start.to_sec() for pnt in trajectory_points]
-        b_matrix = self._compute_bezier_coeff(joint_names,
-                                              trajectory_points,
-                                              dimensions_dict)
+        try:
+            b_matrix = self._compute_bezier_coeff(joint_names,
+                                                  trajectory_points,
+                                                  dimensions_dict)
+        except Exception as ex:
+            rospy.logerr(("{0}: Failed to compute a Bezier trajectory for {1}"
+                         " arm with error \"{2}: {3}\"").format(
+                                                  self._action_name,
+                                                  self._name,
+                                                  type(ex).__name__, ex))
+            self._result.error_code = self._result.INVALID_GOAL
+            self._server.set_aborted(self._result)
+            return
         # Wait for the specified execution time, if not provided use now
         start_time = goal.trajectory.header.stamp.to_sec()
         if start_time == 0.0:

--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -354,6 +354,31 @@ class JointTrajectoryActionServer(object):
         control_rate = rospy.Rate(self._control_rate)
 
         dimensions_dict = self._determine_dimensions(trajectory_points)
+
+        if num_points == 1:
+            # Add current position as trajectory point
+            first_trajectory_point = JointTrajectoryPoint()
+            first_trajectory_point.positions = self._get_current_position(joint_names)
+            if dimensions_dict['velocities']:
+                first_trajectory_point.velocities = [0.0] * len(joint_names)
+            if dimensions_dict['accelerations']:
+                first_trajectory_point.accelerations = [0.0] * len(joint_names)
+            first_trajectory_point.time_from_start = rospy.Duration(0)
+            trajectory_points.insert( 0, first_trajectory_point )
+            num_points = len(trajectory_points)
+
+        if num_points == 2:
+            # Add midpoint of 2 trajectory points
+            mid_trajectory_point = JointTrajectoryPoint()
+            mid_trajectory_point.positions = [(p1 + p2)/2 for (p1, p2) in zip(trajectory_points[0].positions, trajectory_points[1].positions)]
+            if dimensions_dict['velocities']:
+                mid_trajectory_point.velocities = [(v1 + v2)/2 for (v1, v2) in zip(trajectory_points[0].velocities, trajectory_points[1].velocities)]
+            if dimensions_dict['accelerations']:
+                mid_trajectory_point.accelerations = [(a1 + a2)/2 for (a1, a2) in zip(trajectory_points[0].accelerations, trajectory_points[1].accelerations)]
+            mid_trajectory_point.time_from_start = (trajectory_points[0].time_from_start + trajectory_points[1].time_from_start)/2
+            trajectory_points.insert( 1, mid_trajectory_point )
+            num_points = len(trajectory_points)
+       
 	# Force Velocites/Accelerations to zero at the final timestep 
         # if they exist in the trajectory
 	# Remove this behavior if you are stringing together trajectories,

--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -367,18 +367,6 @@ class JointTrajectoryActionServer(object):
             trajectory_points.insert( 0, first_trajectory_point )
             num_points = len(trajectory_points)
 
-        if num_points == 2:
-            # Add midpoint of 2 trajectory points
-            mid_trajectory_point = JointTrajectoryPoint()
-            mid_trajectory_point.positions = [(p1 + p2)/2 for (p1, p2) in zip(trajectory_points[0].positions, trajectory_points[1].positions)]
-            if dimensions_dict['velocities']:
-                mid_trajectory_point.velocities = [(v1 + v2)/2 for (v1, v2) in zip(trajectory_points[0].velocities, trajectory_points[1].velocities)]
-            if dimensions_dict['accelerations']:
-                mid_trajectory_point.accelerations = [(a1 + a2)/2 for (a1, a2) in zip(trajectory_points[0].accelerations, trajectory_points[1].accelerations)]
-            mid_trajectory_point.time_from_start = (trajectory_points[0].time_from_start + trajectory_points[1].time_from_start)/2
-            trajectory_points.insert( 1, mid_trajectory_point )
-            num_points = len(trajectory_points)
-       
 	# Force Velocites/Accelerations to zero at the final timestep 
         # if they exist in the trajectory
 	# Remove this behavior if you are stringing together trajectories,


### PR DESCRIPTION
This is a rebase and modification of PR #54 for release-1.1.1
where the JTAS would error out if too few points were passed into it.
This fixes a bug in the Bezier library which did not properly check for
two points.

@aginika, could you please take a look at this modified pull request?