### PR TITLE
Wait for endpoint states sub to populate in Limb interface

### DIFF
--- a/src/baxter_interface/limb.py
+++ b/src/baxter_interface/limb.py
@@ -119,6 +119,10 @@ class Limb(object):
                    "from %s") % (self.name.capitalize(), joint_state_topic)
         baxter_dataflow.wait_for(lambda: len(self._joint_angle.keys()) > 0,
                                  timeout_msg=err_msg)
+        err_msg = ("%s limb init failed to get current endpoint_state "
+                   "from %s") % (self.name.capitalize(), ns + 'endpoint_state')
+        baxter_dataflow.wait_for(lambda: len(self._cartesian_pose.keys()) > 0,
+                                 timeout_msg=err_msg)
 
     def _on_joint_states(self, msg):
         for idx, name in enumerate(msg.name):


### PR DESCRIPTION
As was pointed out by Luong, in this thread - https://groups.google.com/a/rethinkrobotics.com/forum/#!topic/brr-users/EOt3Bgk7Cmg

When he modified this example IK script - 
https://gist.github.com/rethink-imcmahon/33c34ef39c7aabc85c3e
as follows:
```
def main():
    print("Left Limb")
    ik_test('left')
   
    print("Right Limb")
    ik_test('right')

if __name__ == '__main__':
    sys.exit(main())
```
He effectively added two calls to the `baxter_interface` in quick succession. `baxter_interface.Limb('right').endpoint_state()` for the second side would return an empty dictionary of endpoint states. This was due to the fact that the Limb interface only waits for its `joint_states` to be populated, without checking to be sure at least one `endpoint_state` message was received. This pull request adds that check.