### PR TITLE
Additional info on state changes of buttons

### DIFF
--- a/src/baxter_interface/camera.py
+++ b/src/baxter_interface/camera.py
@@ -75,7 +75,7 @@ class CameraController(object):
 
         list_svc = rospy.ServiceProxy('/cameras/list', ListCameras)
         rospy.wait_for_service('/cameras/list', timeout=10)
-        if not self._id in list_svc().cameras:
+        if not self._id in ["left_hand_camera","right_hand_camera","head_camera"]:
             raise AttributeError(
                 ("Cannot locate a service for camera name '{0}'. "
                 "Close a different camera first and try again.".format(self._id)))

--- a/src/baxter_interface/digital_io.py
+++ b/src/baxter_interface/digital_io.py
@@ -95,7 +95,7 @@ class DigitalIO(object):
 
         # trigger signal if changed
         if old_state is not None and old_state != new_state:
-            self.state_changed(new_state)
+            self.state_changed(new_state,self._id)
 
     @property
     def is_output(self):

--- a/src/baxter_interface/navigator.py
+++ b/src/baxter_interface/navigator.py
@@ -177,11 +177,11 @@ class Navigator(object):
                    ]
         for i, signal in enumerate(buttons):
             if old_state.buttons[i] != msg.buttons[i]:
-                signal(msg.buttons[i])
+                signal(msg.buttons[i],self._id,"button",i)
 
         if old_state.wheel != msg.wheel:
             diff = msg.wheel - old_state.wheel
             if abs(diff % 256) < 127:
-                self.wheel_changed(diff % 256)
+                self.wheel_changed(diff % 256,self._id,"wheel",msg.wheel)
             else:
-                self.wheel_changed(diff % (-256))
+                self.wheel_changed(diff % (-256),self._id,"wheel",msg.wheel)


### PR DESCRIPTION
## DigitalIO and Navigators
This little improvement enables you to see which buttons was pressed in your callback function. 
Therefore you need only one callback function for all your buttons.
e.g.:
```
from baxter_interface.digital_io import DigitalIO
def updateState(*args):
    print "button pressed", args
button = DigitalIO("left_shoulder_button")
button.state_changed.connect(updateState)    
```

## Camera
The current implementation raises an exception, if the camera is currently closed.  I think it is useful in the camera controller to check, if the camera is opened or closed. Also in the past the service call to the camera list yielded all 3 cameras, which is not the case any more. Therefore I recommend to change the condition of the if in the __init__