### PR TITLE
Resolves #63 by creating a copy of signal funcs

### DIFF
--- a/src/baxter_dataflow/signals.py
+++ b/src/baxter_dataflow/signals.py
@@ -40,7 +40,7 @@ class Signal(object):
         self._methods = WeakKeyDictionary()
 
     def __call__(self, *args, **kargs):
-        for f in self._functions:
+        for f in self._functions[:]:
             f(*args, **kargs)
 
         for obj, functions in self._methods.items():


### PR DESCRIPTION
Rather than iterating over the functions to be called, and having them change in number underneath us, create a copy of them and then iterate.