### PR TITLE
Revert Signal Fix 49d233f

### DIFF
--- a/src/baxter_dataflow/signals.py
+++ b/src/baxter_dataflow/signals.py
@@ -40,7 +40,7 @@ class Signal(object):
         self._methods = WeakKeyDictionary()
 
     def __call__(self, *args, **kargs):
-        for f in self._functions[:]:
+        for f in self._functions:
             f(*args, **kargs)
 
         for obj, functions in self._methods.items():


### PR DESCRIPTION
Reverts RethinkRobotics/baxter_interface#64 
This error:
```
 [ERROR] [WallTime: 1447099832.166541] bad callback: <bound method
 Gripper._on_gripper_state of <baxter_interface.gripper.Gripper object at
 0x7fc0b68d0710>>
 Traceback (most recent call last):
   File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/topics.py", line
 711, in _invoke_callback
     cb(msg)
   File
 "/data/users/qagroup/ros_ws/src/baxter_interface/src/baxter_interface/gripper.py",
 line 143, in _on_gripper_state
     self.on_moving_changed(state.moving == True)
   File
 "/data/users/qagroup/ros_ws/src/baxter_interface/src/baxter_dataflow/signals.py",
 line 43, in __call__
     for f in self._functions[:]:
 TypeError: 'WeakSet' object has no attribute '__getitem__'
```
Can be recreated by:
 1. init shell (either on robot or on workstation)
 2. enable robot
 3. launch keyboard control example ( 'rosrun baxter_examples
 joint_position_keyboard.py' )
 4. attempt to enable a gripper through keyboard control (left: '/' right:
 'b')
    a. noted output will be displayed
 5. close gripper through keyboard control (left: ',', right: 'c')
    a. noted output will be displayed
 5. open gripper through keyboard control (left: 'm', right: 'x')
    a. noted output will be displayed