### PR TITLE
Fix Limb interf to ignore extra left/right states

### DIFF
--- a/src/baxter_interface/limb.py
+++ b/src/baxter_interface/limb.py
@@ -126,7 +126,7 @@ class Limb(object):
 
     def _on_joint_states(self, msg):
         for idx, name in enumerate(msg.name):
-            if self.name in name:
+            if name in self._joint_names[self.name]:
                 self._joint_angle[name] = msg.position[idx]
                 self._joint_velocity[name] = msg.velocity[idx]
                 self._joint_effort[name] = msg.effort[idx]


### PR DESCRIPTION
Prior to this commit, the on_joint_states callback
would look for any "left" or "right" string and
populate its joint states with that joint. This
commit now limits the search to only look for joints
that are previously know to exist in the Baxter arm.