### PR TITLE
always add current poisition as the first point in trajectory points

### DIFF
--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -361,7 +361,7 @@ class JointTrajectoryActionServer(object):
 
         dimensions_dict = self._determine_dimensions(trajectory_points)
 
-        if num_points == 1:
+        if num_points >= 1 and trajectory_points[0].time_from_start.to_sec() > 0:
             # Add current position as trajectory point
             first_trajectory_point = JointTrajectoryPoint()
             first_trajectory_point.positions = self._get_current_position(joint_names)


### PR DESCRIPTION
hi, currently, joint trajectoy action server behavios

if points is 1, add current position to the first point in trajectory points

others, assuming that user set current position to the first point in trajectory points

Is there any reason to do this? why not always put first point in trajectory points ?

c.f https://github.com/RethinkRobotics/baxter_interface/pull/55, https://github.com/RethinkRobotics/baxter_interface/pull/55
