### PR TITLE
Change first point in trajectory to commanded position

### DIFF
--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -361,7 +361,7 @@ class JointTrajectoryActionServer(object):
 
         dimensions_dict = self._determine_dimensions(trajectory_points)
 
-        if num_points >= 1 and trajectory_points[0].time_from_start.to_sec() > 0:
+        if trajectory_points[0].time_from_start.to_sec() > 0: # it already retuned when num_points == 0 (see 10 lines above)
             # Add current position as trajectory point
             first_trajectory_point = JointTrajectoryPoint()
             first_trajectory_point.positions = self._get_current_position(joint_names)

--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -194,6 +194,9 @@ class JointTrajectoryActionServer(object):
         error = map(operator.sub, set_point, current)
         return zip(joint_names, error)
 
+    def _get_commanded_position(self, joint_names):
+        return [self._limb.joint_commanded_angle(joint) for joint in joint_names]
+
     def _update_feedback(self, cmd_point, jnt_names, cur_time):
         self._fdbk.header.stamp = rospy.Duration.from_sec(rospy.get_time())
         self._fdbk.joint_names = jnt_names
@@ -364,7 +367,7 @@ class JointTrajectoryActionServer(object):
         if trajectory_points[0].time_from_start.to_sec() > 0: # it already retuned when num_points == 0 (see 10 lines above)
             # Add current position as trajectory point
             first_trajectory_point = JointTrajectoryPoint()
-            first_trajectory_point.positions = self._get_current_position(joint_names)
+            first_trajectory_point.positions = self._get_commanded_position(joint_names)
             # To preserve desired velocities and accelerations, copy them to the first
             # trajectory point if the trajectory is only 1 point.
             if dimensions_dict['velocities']:

--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -361,7 +361,7 @@ class JointTrajectoryActionServer(object):
 
         dimensions_dict = self._determine_dimensions(trajectory_points)
 
-        if num_points == 1:
+        if num_points >= 1 and trajectory_points[0].time_from_start.to_sec() > 0:
             # Add current position as trajectory point
             first_trajectory_point = JointTrajectoryPoint()
             first_trajectory_point.positions = self._get_current_position(joint_names)


### PR DESCRIPTION
MERGE AFTER ~~#74~~ #79 
### What is problem
Please see https://github.com/jsk-ros-pkg/jsk_robot/issues/738#issue-193413329
### What changed
* Subscribe `/robot/limb/<left|right>/gravity_compensation_torques` to get current commanded joint position. This position is changed even if Baxter's arm is moved manually.
* If `time_from_start` of first trajectory point isn't zero, add current commanded position as the first point instead of current joint position in case of commanded position and current position are too different.

cc @k-okada