### PR TITLE
Minor tweak for Python 3 compatibility

### DIFF
--- a/src/baxter_interface/robot_enable.py
+++ b/src/baxter_interface/robot_enable.py
@@ -164,7 +164,7 @@ http://sdk.rethinkrobotics.com/wiki/RSDK_Shell#Initialize
                 timeout_msg=error_env,
                 body=pub.publish
             )
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.ETIMEDOUT:
                 if self._state.error == True and self._state.stopped == False:
                     rospy.logwarn(error_nonfatal)


### PR DESCRIPTION
This is one of several pull request for getting the Baxter simulation to work in ROS Noetic with python 3 and Qt5.  It is intended to be merged into a `noetic_devel` branch.  There is an update from another repository that is required for the simulator to work in Noetic:

[https://github.com/EmaroLab/baxter_simulator](https://github.com/EmaroLab/baxter_simulator)
